### PR TITLE
Update README.md with valid bibtex formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you use this library for research, please include the following reference in 
 @inproceedings{DYRECTsn,
     author={Maile, Lisa and Hielscher, Kai-Steffen and German, Reinhard},
     editor={Kalyvianaki, Evangelia and Paolieri, Marco},
-    title={{Combining Static and Dynamic Traffic with Delay Guarantees in Time-Sensitive Networking},
+    title={{Combining Static and Dynamic Traffic with Delay Guarantees in Time-Sensitive Networking}},
     booktitle={Performance Evaluation Methodologies and Tools},
     year={2024},
     publisher={Springer Nature Switzerland},


### PR DESCRIPTION
The title-field of DYRECTsn is wrapped in a double {{ to preserve case, but the line lacks the final } to close it. Adding this will resolve the bibtex following bibtex error:

"""
syntax error: found "@article", expected end of entry ("}" or ")") (skipping to next "@")" """